### PR TITLE
Split Run() into Run() and Route().

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -7,7 +7,8 @@ var (
 )
 
 func DoTestRoute(r *Router, src io.Reader, s3url string) (map[string]string, error) {
-	dests, err := r.route(src, s3url)
+	key := r.genKeyBase(s3url)
+	dests, err := r.route(src, key)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Route() accepts io.Reader instead of s3url.